### PR TITLE
Correct localForage size

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		<!-- For syntax highlighting -->
 		<link rel="stylesheet" href="lib/css/zenburn.css">
 
-		<link rel="stylesheet" href="index.css">
+		<link rel="st7ylesheet" href="index.css">
 
 		<!-- If the query includes 'print-pdf', include the PDF print sheet -->
 		<script>
@@ -303,7 +303,7 @@
             and what if there was a single API that worked across all three?
             LocalStorage accomplishes this remarkable feat, abstracting away the
             nitty-gritty details of the different storage APIs, while still
-            providing a svelte library that's under 7MB.
+            providing a svelte library that's under 30kB.
           </aside>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		<!-- For syntax highlighting -->
 		<link rel="stylesheet" href="lib/css/zenburn.css">
 
-		<link rel="st7ylesheet" href="index.css">
+		<link rel="stylesheet" href="index.css">
 
 		<!-- If the query includes 'print-pdf', include the PDF print sheet -->
 		<script>


### PR DESCRIPTION
I'm so conceited, I corrected things about me first ;-)

Really though, I don't think of localForage as particularly small, but it IS
under 7MB ;-) I'm using the minified version as a reference point here,
which is 25kB with Promises, so lets just say "under 30kB" if that's cool
with you.
